### PR TITLE
feat: warn if imported variable value name not valid

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,10 @@ const path = require('path');
 const BroccoliFilter = require('broccoli-persistent-filter');
 const md5Hex = require('md5-hex');
 
-const IMPORT_PATTERN = /\{\{\s*import\s+(\w+)\s+from\s+['"]([^'"]+)['"]\s*\}\}/gi;
+const IMPORT_PATTERN = /\{\{\s*import\s+([^\s]+)\s+from\s+['"]([^'"]+)['"]\s*\}\}/gi;
 
 function isValidVariableName(name) {
-  if (!(/^[A-Za-z]+$/.test(name))) {
+  if (!(/^[A-Za-z0-9]+$/.test(name))) {
     return false;
   }
   if (name.charAt(0).toUpperCase() !== name.charAt(0)) {

--- a/index.js
+++ b/index.js
@@ -61,15 +61,20 @@ class TemplateImportProcessor extends BroccoliFilter {
     let header = imports.map(({ importPath, localName, isLocalNameValid }) => {
       const warnPrefix = 'ember-template-component-import: ';
       const abstractWarn = `${warnPrefix} Allowed import variable names - CamelCased strings, like: FooBar, TomDale`;
-      const componentWarn =  `${warnPrefix}Warning! "${localName}" is not allowed as Variable name for Template import`;
+      const componentWarn =  `
+        ${warnPrefix}Warning!
+        in file: "${relativePath}" 
+        subject: "${localName}" is not allowed as Variable name for Template import.`;
       const warn = isLocalNameValid ? '' : `
-        {{log '${componentWarn}'}}
-        {{log '${abstractWarn}'}}
         <pre data-test-name="${localName}">${componentWarn}</pre>
         <pre data-test-global-warn="${localName}">${abstractWarn}</pre>
       `;
       if (!isLocalNameValid) {
         this._console.log(componentWarn);
+        if (relativePath !== 'dummy/pods/application/template.hbs') {
+          // don't throw on 'dummy/pods/application/template.hbs' (test template)
+          throw new Error(componentWarn);
+        }
       }
       return `${warn}{{#let (component '${ importPath }') as |${ localName }|}}`;
     }).join('');

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const path = require('path');
 const BroccoliFilter = require('broccoli-persistent-filter');
 const md5Hex = require('md5-hex');
 
-const IMPORT_PATTERN = /\{\{\s*import\s*(\w+)\s*from\s*['"]([^'"]+)['"]\s*\}\}/gi;
+const IMPORT_PATTERN = /\{\{\s*import\s+(\w+)\s+from\s+['"]([^'"]+)['"]\s*\}\}/gi;
 
 function isValidVariableName(name) {
   if (!(/^[A-Za-z]+$/.test(name))) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const path = require('path');
 const BroccoliFilter = require('broccoli-persistent-filter');
 const md5Hex = require('md5-hex');
 
-const IMPORT_PATTERN = /\{\{\s*import (\w+) from ['"]([^'"]+)['"]\s*\}\}/gi;
+const IMPORT_PATTERN = /\{\{\s*import\s*(\w+)\s*from\s*['"]([^'"]+)['"]\s*\}\}/gi;
 
 function isValidVariableName(name) {
   if (!(/^[A-Za-z]+$/.test(name))) {

--- a/index.js
+++ b/index.js
@@ -62,13 +62,15 @@ class TemplateImportProcessor extends BroccoliFilter {
       const warnPrefix = 'ember-template-component-import: ';
       const abstractWarn = `${warnPrefix} Allowed import variable names - CamelCased strings, like: FooBar, TomDale`;
       const componentWarn =  `${warnPrefix}Warning! "${localName}" is not allowed as Variable name for Template import`;
-      this._console.log(componentWarn);
       const warn = isLocalNameValid ? '' : `
         {{log '${componentWarn}'}}
         {{log '${abstractWarn}'}}
         <pre data-test-name="${localName}">${componentWarn}</pre>
         <pre data-test-global-warn="${localName}">${abstractWarn}</pre>
       `;
+      if (!isLocalNameValid) {
+        this._console.log(componentWarn);
+      }
       return `${warn}{{#let (component '${ importPath }') as |${ localName }|}}`;
     }).join('');
     let footer = imports.map(() => `{{/let}}`).join('');

--- a/tests/acceptance/import-test.js
+++ b/tests/acceptance/import-test.js
@@ -27,6 +27,6 @@ module('Acceptance | import', function(hooks) {
 
     assert.equal(findAll('[data-test-global-warn]').length, 4);
     assert.equal(findAll('.global-button').length, 3);
-    assert.equal(findAll('.local-button').length, 3);
+    assert.equal(findAll('.local-button').length, 4);
   });
 });

--- a/tests/acceptance/import-test.js
+++ b/tests/acceptance/import-test.js
@@ -11,8 +11,8 @@ module('Acceptance | import', function(hooks) {
     assert.equal(find('.local-button').innerText, "I'm a locally referenced button");
     assert.equal(find('[data-test-name="incorrectlyCamelCasedAbsoluteImport"]').innerText, 'ember-template-component-import: Warning! "incorrectlyCamelCasedAbsoluteImport" is not allowed as Variable name for Template import');
     assert.equal(find('[data-test-name="incorrectlyCamelCasedRelativeImport"]').innerText, 'ember-template-component-import: Warning! "incorrectlyCamelCasedRelativeImport" is not allowed as Variable name for Template import');
-    assert.equal(find('[data-test-name="Pseudo_Valid_Global"]').innerText, 'ember-template-component-import: Warning! "Pseudo_Valid_Global" is not allowed as Variable name for Template import');
-    assert.equal(find('[data-test-name="Pseudo_Valid_Local"]').innerText, 'ember-template-component-import: Warning! "Pseudo_Valid_Local" is not allowed as Variable name for Template import');
+    assert.equal(find('[data-test-name="Incorrectly_Snake_Cased_Absolute_Import"]').innerText, 'ember-template-component-import: Warning! "Incorrectly_Snake_Cased_Absolute_Import" is not allowed as Variable name for Template import');
+    assert.equal(find('[data-test-name="Incorrectly_Snake_Cased_Relative_Import"]').innerText, 'ember-template-component-import: Warning! "Incorrectly_Snake_Cased_Relative_Import" is not allowed as Variable name for Template import');
     assert.equal(findAll('[data-test-global-warn]').length, 4);
     assert.equal(findAll('.global-button').length, 3);
     assert.equal(findAll('.local-button').length, 3);

--- a/tests/acceptance/import-test.js
+++ b/tests/acceptance/import-test.js
@@ -9,8 +9,8 @@ module('Acceptance | import', function(hooks) {
     await visit('/');
     assert.equal(find('.global-button').innerText, "I'm a globally referenced button");
     assert.equal(find('.local-button').innerText, "I'm a locally referenced button");
-    assert.equal(find('[data-test-name="dirtyNamedGlobal"]').innerText, 'ember-template-component-import: Warning! "dirtyNamedGlobal" is not allowed as Variable name for Template import');
-    assert.equal(find('[data-test-name="dirtyNamedLocal"]').innerText, 'ember-template-component-import: Warning! "dirtyNamedLocal" is not allowed as Variable name for Template import');
+    assert.equal(find('[data-test-name="incorrectlyCamelCasedAbsoluteImport"]').innerText, 'ember-template-component-import: Warning! "incorrectlyCamelCasedAbsoluteImport" is not allowed as Variable name for Template import');
+    assert.equal(find('[data-test-name="incorrectlyCamelCasedRelativeImport"]').innerText, 'ember-template-component-import: Warning! "incorrectlyCamelCasedRelativeImport" is not allowed as Variable name for Template import');
     assert.equal(find('[data-test-name="Pseudo_Valid_Global"]').innerText, 'ember-template-component-import: Warning! "Pseudo_Valid_Global" is not allowed as Variable name for Template import');
     assert.equal(find('[data-test-name="Pseudo_Valid_Local"]').innerText, 'ember-template-component-import: Warning! "Pseudo_Valid_Local" is not allowed as Variable name for Template import');
     assert.equal(findAll('[data-test-global-warn]').length, 4);

--- a/tests/acceptance/import-test.js
+++ b/tests/acceptance/import-test.js
@@ -9,10 +9,22 @@ module('Acceptance | import', function(hooks) {
     await visit('/');
     assert.equal(find('.global-button').innerText, "I'm a globally referenced button");
     assert.equal(find('.local-button').innerText, "I'm a locally referenced button");
-    assert.equal(find('[data-test-name="incorrectlyCamelCasedAbsoluteImport"]').innerText, 'ember-template-component-import: Warning! "incorrectlyCamelCasedAbsoluteImport" is not allowed as Variable name for Template import');
-    assert.equal(find('[data-test-name="incorrectlyCamelCasedRelativeImport"]').innerText, 'ember-template-component-import: Warning! "incorrectlyCamelCasedRelativeImport" is not allowed as Variable name for Template import');
-    assert.equal(find('[data-test-name="Incorrectly_Snake_Cased_Absolute_Import"]').innerText, 'ember-template-component-import: Warning! "Incorrectly_Snake_Cased_Absolute_Import" is not allowed as Variable name for Template import');
-    assert.equal(find('[data-test-name="Incorrectly_Snake_Cased_Relative_Import"]').innerText, 'ember-template-component-import: Warning! "Incorrectly_Snake_Cased_Relative_Import" is not allowed as Variable name for Template import');
+    const incorrectlyCamelCasedAbsoluteImportText = find('[data-test-name="incorrectlyCamelCasedAbsoluteImport"]').innerText;
+    const incorrectlyCamelCasedRelativeImportText = find('[data-test-name="incorrectlyCamelCasedRelativeImport"]').innerText;
+    const Incorrectly_Snake_Cased_Absolute_ImportText = find('[data-test-name="Incorrectly_Snake_Cased_Absolute_Import"]').innerText;
+    const Incorrectly_Snake_Cased_Relative_ImportText = find('[data-test-name="Incorrectly_Snake_Cased_Relative_Import"]').innerText;
+
+    assert.equal(incorrectlyCamelCasedAbsoluteImportText.includes('dummy/pods/application/template.hbs'), true);
+    assert.equal(incorrectlyCamelCasedAbsoluteImportText.includes('"incorrectlyCamelCasedAbsoluteImport"'), true);
+    assert.equal(incorrectlyCamelCasedRelativeImportText.includes('dummy/pods/application/template.hbs'), true);
+    assert.equal(incorrectlyCamelCasedRelativeImportText.includes('"incorrectlyCamelCasedRelativeImport"'), true);
+
+    
+    assert.equal(Incorrectly_Snake_Cased_Absolute_ImportText.includes('dummy/pods/application/template.hbs'), true);
+    assert.equal(Incorrectly_Snake_Cased_Absolute_ImportText.includes('"Incorrectly_Snake_Cased_Absolute_Import"'), true);
+    assert.equal(Incorrectly_Snake_Cased_Relative_ImportText.includes('dummy/pods/application/template.hbs'), true);
+    assert.equal(Incorrectly_Snake_Cased_Relative_ImportText.includes('"Incorrectly_Snake_Cased_Relative_Import"'), true);
+
     assert.equal(findAll('[data-test-global-warn]').length, 4);
     assert.equal(findAll('.global-button').length, 3);
     assert.equal(findAll('.local-button').length, 3);

--- a/tests/acceptance/import-test.js
+++ b/tests/acceptance/import-test.js
@@ -11,8 +11,10 @@ module('Acceptance | import', function(hooks) {
     assert.equal(find('.local-button').innerText, "I'm a locally referenced button");
     assert.equal(find('[data-test-name="dirtyNamedGlobal"]').innerText, 'ember-template-component-import: Warning! "dirtyNamedGlobal" is not allowed as Variable name for Template import');
     assert.equal(find('[data-test-name="dirtyNamedLocal"]').innerText, 'ember-template-component-import: Warning! "dirtyNamedLocal" is not allowed as Variable name for Template import');
-    assert.equal(findAll('[data-test-global-warn]').length, 2);
-    assert.equal(findAll('.global-button').length, 2);
-    assert.equal(findAll('.local-button').length, 2);
+    assert.equal(find('[data-test-name="Pseudo_Valid_Global"]').innerText, 'ember-template-component-import: Warning! "Pseudo_Valid_Global" is not allowed as Variable name for Template import');
+    assert.equal(find('[data-test-name="Pseudo_Valid_Local"]').innerText, 'ember-template-component-import: Warning! "Pseudo_Valid_Local" is not allowed as Variable name for Template import');
+    assert.equal(findAll('[data-test-global-warn]').length, 4);
+    assert.equal(findAll('.global-button').length, 3);
+    assert.equal(findAll('.local-button').length, 3);
   });
 });

--- a/tests/acceptance/import-test.js
+++ b/tests/acceptance/import-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit, find } from '@ember/test-helpers';
+import { visit, find, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
 module('Acceptance | import', function(hooks) {
@@ -9,5 +9,10 @@ module('Acceptance | import', function(hooks) {
     await visit('/');
     assert.equal(find('.global-button').innerText, "I'm a globally referenced button");
     assert.equal(find('.local-button').innerText, "I'm a locally referenced button");
+    assert.equal(find('[data-test-name="dirtyNamedGlobal"]').innerText, 'ember-template-component-import: Warning! "dirtyNamedGlobal" is not allowed as Variable name for Template import');
+    assert.equal(find('[data-test-name="dirtyNamedLocal"]').innerText, 'ember-template-component-import: Warning! "dirtyNamedLocal" is not allowed as Variable name for Template import');
+    assert.equal(findAll('[data-test-global-warn]').length, 2);
+    assert.equal(findAll('.global-button').length, 2);
+    assert.equal(findAll('.local-button').length, 2);
   });
 });

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -1,5 +1,6 @@
 {{import Button from "ui/button"}}
 {{import SecondButton from "./button"}}
+{{import ButtonWithNumber5 from "./button"}};
 {{import incorrectlyCamelCasedAbsoluteImport from "ui/button"}}
 {{import incorrectlyCamelCasedRelativeImport from "./button"}}
 {{import Incorrectly_Snake_Cased_Absolute_Import from "ui/button"}}
@@ -7,6 +8,7 @@
 
 <Button>I'm a globally referenced button</Button>
 <SecondButton>I'm a locally referenced button</SecondButton>
+<ButtonWithNumber5>I'm ButtonWithNumber5InComponentName</ButtonWithNumber5>
 <incorrectlyCamelCasedAbsoluteImport>I'm a dirty named global button</incorrectlyCamelCasedAbsoluteImport>
 <incorrectlyCamelCasedRelativeImport>I'm a dirty named global button</incorrectlyCamelCasedRelativeImport>
 <Incorrectly_Snake_Cased_Absolute_Import>I'm a underscored global button</Incorrectly_Snake_Cased_Absolute_Import>

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -1,13 +1,13 @@
 {{import Button from "ui/button"}}
 {{import LocalButton from "./button"}}
-{{import dirtyNamedGlobal from "ui/button"}}
-{{import dirtyNamedLocal from "./button"}}
+{{import incorrectlyCamelCasedAbsoluteImport from "ui/button"}}
+{{import incorrectlyCamelCasedRelativeImport from "./button"}}
 {{import Pseudo_Valid_Global from "ui/button"}}
 {{import Pseudo_Valid_Local from "./button"}}
 
 <Button>I'm a globally referenced button</Button>
 <LocalButton>I'm a locally referenced button</LocalButton>
-<dirtyNamedGlobal>I'm a dirty named global button</dirtyNamedGlobal>
-<dirtyNamedLocal>I'm a dirty named global button</dirtyNamedLocal>
+<incorrectlyCamelCasedAbsoluteImport>I'm a dirty named global button</incorrectlyCamelCasedAbsoluteImport>
+<incorrectlyCamelCasedRelativeImport>I'm a dirty named global button</incorrectlyCamelCasedRelativeImport>
 <Pseudo_Valid_Global>I'm a underscored global button</Pseudo_Valid_Global>
 <Pseudo_Valid_Local>I'm a underscored local button</Pseudo_Valid_Local>

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -1,12 +1,12 @@
 {{import Button from "ui/button"}}
-{{import RelativeButton from "./button"}}
+{{import SecondButton from "./button"}}
 {{import incorrectlyCamelCasedAbsoluteImport from "ui/button"}}
 {{import incorrectlyCamelCasedRelativeImport from "./button"}}
 {{import Incorrectly_Snake_Cased_Absolute_Import from "ui/button"}}
 {{import Incorrectly_Snake_Cased_Relative_Import from "./button"}}
 
 <Button>I'm a globally referenced button</Button>
-<RelativeButton>I'm a locally referenced button</RelativeButton>
+<SecondButton>I'm a locally referenced button</SecondButton>
 <incorrectlyCamelCasedAbsoluteImport>I'm a dirty named global button</incorrectlyCamelCasedAbsoluteImport>
 <incorrectlyCamelCasedRelativeImport>I'm a dirty named global button</incorrectlyCamelCasedRelativeImport>
 <Incorrectly_Snake_Cased_Absolute_Import>I'm a underscored global button</Incorrectly_Snake_Cased_Absolute_Import>

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -1,5 +1,9 @@
 {{import Button from "ui/button"}}
 {{import LocalButton from "./button"}}
+{{import dirtyNamedGlobal from "ui/button"}}
+{{import dirtyNamedLocal from "./button"}}
 
 <Button>I'm a globally referenced button</Button>
 <LocalButton>I'm a locally referenced button</LocalButton>
+<dirtyNamedGlobal>I'm a dirty named global button</dirtyNamedGlobal>
+<dirtyNamedLocal>I'm a dirty named global button</dirtyNamedLocal>

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -2,8 +2,12 @@
 {{import LocalButton from "./button"}}
 {{import dirtyNamedGlobal from "ui/button"}}
 {{import dirtyNamedLocal from "./button"}}
+{{import Pseudo_Valid_Global from "ui/button"}}
+{{import Pseudo_Valid_Local from "./button"}}
 
 <Button>I'm a globally referenced button</Button>
 <LocalButton>I'm a locally referenced button</LocalButton>
 <dirtyNamedGlobal>I'm a dirty named global button</dirtyNamedGlobal>
 <dirtyNamedLocal>I'm a dirty named global button</dirtyNamedLocal>
+<Pseudo_Valid_Global>I'm a underscored global button</Pseudo_Valid_Global>
+<Pseudo_Valid_Local>I'm a underscored local button</Pseudo_Valid_Local>

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -1,12 +1,12 @@
 {{import Button from "ui/button"}}
-{{import LocalButton from "./button"}}
+{{import RelativeButton from "./button"}}
 {{import incorrectlyCamelCasedAbsoluteImport from "ui/button"}}
 {{import incorrectlyCamelCasedRelativeImport from "./button"}}
 {{import Incorrectly_Snake_Cased_Absolute_Import from "ui/button"}}
 {{import Incorrectly_Snake_Cased_Relative_Import from "./button"}}
 
 <Button>I'm a globally referenced button</Button>
-<LocalButton>I'm a locally referenced button</LocalButton>
+<RelativeButton>I'm a locally referenced button</RelativeButton>
 <incorrectlyCamelCasedAbsoluteImport>I'm a dirty named global button</incorrectlyCamelCasedAbsoluteImport>
 <incorrectlyCamelCasedRelativeImport>I'm a dirty named global button</incorrectlyCamelCasedRelativeImport>
 <Incorrectly_Snake_Cased_Absolute_Import>I'm a underscored global button</Incorrectly_Snake_Cased_Absolute_Import>

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -2,12 +2,12 @@
 {{import LocalButton from "./button"}}
 {{import incorrectlyCamelCasedAbsoluteImport from "ui/button"}}
 {{import incorrectlyCamelCasedRelativeImport from "./button"}}
-{{import Pseudo_Valid_Global from "ui/button"}}
-{{import Pseudo_Valid_Local from "./button"}}
+{{import Incorrectly_Snake_Cased_Absolute_Import from "ui/button"}}
+{{import Incorrectly_Snake_Cased_Relative_Import from "./button"}}
 
 <Button>I'm a globally referenced button</Button>
 <LocalButton>I'm a locally referenced button</LocalButton>
 <incorrectlyCamelCasedAbsoluteImport>I'm a dirty named global button</incorrectlyCamelCasedAbsoluteImport>
 <incorrectlyCamelCasedRelativeImport>I'm a dirty named global button</incorrectlyCamelCasedRelativeImport>
-<Pseudo_Valid_Global>I'm a underscored global button</Pseudo_Valid_Global>
-<Pseudo_Valid_Local>I'm a underscored local button</Pseudo_Valid_Local>
+<Incorrectly_Snake_Cased_Absolute_Import>I'm a underscored global button</Incorrectly_Snake_Cased_Absolute_Import>
+<Incorrectly_Snake_Cased_Relative_Import>I'm a underscored local button</Incorrectly_Snake_Cased_Relative_Import>

--- a/tests/dummy/app/pods/different-imports/template.hbs
+++ b/tests/dummy/app/pods/different-imports/template.hbs
@@ -1,12 +1,12 @@
 // spaced
 {{ import Button from "ui/button" }}
 // tabbed
-{{  import    RelativeButton from    "application/button"    }}
+{{  import    SecondButton from    "application/button"    }}
 // mixed
 {{  import            ButtonButton           from          "ui/button"  }}
 // newlined
 {{import 
-  RelativeButtonRelativeButton 
+  SecondButtonSecondButton 
   from
   "application/button"
 }}
@@ -18,14 +18,14 @@
 }}
 // newlined mixed with tabs and spaces
 {{  import 
-  RelativeButtonRelativeButtonRelativeButton    
+  SecondButtonSecondButtonSecondButton    
   from           
   "application/button"                  
 }}
 
 <Button>b1</Button>
-<RelativeButton>b1</RelativeButton>
+<SecondButton>b1</SecondButton>
 <ButtonButton>b3</ButtonButton>
-<RelativeButtonRelativeButton>b4</RelativeButtonRelativeButton>
-<RelativeButtonRelativeButtonRelativeButton>b5</RelativeButtonRelativeButtonRelativeButton>
+<SecondButtonSecondButton>b4</SecondButtonSecondButton>
+<SecondButtonSecondButtonSecondButton>b5</SecondButtonSecondButtonSecondButton>
 <ButtonButtonButton>b6</ButtonButtonButton>

--- a/tests/dummy/app/pods/different-imports/template.hbs
+++ b/tests/dummy/app/pods/different-imports/template.hbs
@@ -1,12 +1,12 @@
 // spaced
 {{ import Button from "ui/button" }}
 // tabbed
-{{  import    LocalButton from    "application/button"    }}
+{{  import    RelativeButton from    "application/button"    }}
 // mixed
 {{  import            ButtonButton           from          "ui/button"  }}
 // newlined
 {{import 
-  LocalButtonLocalButton 
+  RelativeButtonRelativeButton 
   from
   "application/button"
 }}
@@ -18,14 +18,14 @@
 }}
 // newlined mixed with tabs and spaces
 {{  import 
-  LocalButtonLocalButtonLocalButton    
+  RelativeButtonRelativeButtonRelativeButton    
   from           
   "application/button"                  
 }}
 
 <Button>b1</Button>
-<LocalButton>b1</LocalButton>
+<RelativeButton>b1</RelativeButton>
 <ButtonButton>b3</ButtonButton>
-<LocalButtonLocalButton>b4</LocalButtonLocalButton>
-<LocalButtonLocalButtonLocalButton>b5</LocalButtonLocalButtonLocalButton>
+<RelativeButtonRelativeButton>b4</RelativeButtonRelativeButton>
+<RelativeButtonRelativeButtonRelativeButton>b5</RelativeButtonRelativeButtonRelativeButton>
 <ButtonButtonButton>b6</ButtonButtonButton>

--- a/tests/dummy/app/pods/different-imports/template.hbs
+++ b/tests/dummy/app/pods/different-imports/template.hbs
@@ -1,0 +1,31 @@
+// spaced
+{{ import Button from "ui/button" }}
+// tabbed
+{{  import    LocalButton from    "application/button"    }}
+// mixed
+{{  import            ButtonButton           from          "ui/button"  }}
+// newlined
+{{import 
+  LocalButtonLocalButton 
+  from
+  "application/button"
+}}
+// newlined mixed
+{{import 
+  ButtonButtonButton             
+  from           
+  "ui/button"   
+}}
+// newlined mixed with tabs and spaces
+{{  import 
+  LocalButtonLocalButtonLocalButton    
+  from           
+  "application/button"                  
+}}
+
+<Button>b1</Button>
+<LocalButton>b1</LocalButton>
+<ButtonButton>b3</ButtonButton>
+<LocalButtonLocalButton>b4</LocalButtonLocalButton>
+<LocalButtonLocalButtonLocalButton>b5</LocalButtonLocalButtonLocalButton>
+<ButtonButtonButton>b6</ButtonButtonButton>

--- a/tests/integration/pods/formatted-import-test.js
+++ b/tests/integration/pods/formatted-import-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, findAll } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | different-imports', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it can handle spaces, tabbed, multilined imports', async function(assert) {
+    await render(hbs`{{different-imports}}`);
+    assert.equal(findAll('button').length, 6);
+  });
+});


### PR DESCRIPTION
added isValidVariableName function, to check is valid template variable name or not.
Looks like it can fix:
* https://github.com/crashco/ember-template-component-import/issues/1
* https://github.com/crashco/ember-template-component-import/issues/3
* https://github.com/crashco/ember-template-component-import/issues/4