### PR TITLE
remove podModulePrefix check

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,11 +96,6 @@ module.exports = {
       componentsRoot = path.join(this.project.root, podModulePrefix);
     }
 
-    assert.notStrictEqual(
-      podModulePrefix,
-      undefined,
-      `${this.name}: 'podModulePrefix' has not been defined in config/environment.js`
-    );
     registry.add('template', {
       name: 'ember-template-component-import',
       ext: 'hbs',


### PR DESCRIPTION
is it still needed? i mean, there is a check for podModulePrefix === undefined before :)